### PR TITLE
Investigate false positive test

### DIFF
--- a/src/Cshart/Cshart.Tests/Chart_Add.cs
+++ b/src/Cshart/Cshart.Tests/Chart_Add.cs
@@ -52,30 +52,7 @@ namespace Cshart.Tests
                         new DotNode(node.Children.Single().Id)));
 
                 using var a = new AssertionScope();
-                graph.Should().BeEquivalentTo(graph2);
-                // https://github.com/fluentassertions/fluentassertions/issues/978#issuecomment-441060261
-                // var cluster = graph.Elements.First();
-                // var cluster2 = graph2.Elements.First();
-                var cluster = graph.Elements.First() as DotSubGraph;
-                var cluster2 = graph2.Elements.First() as DotSubGraph;
-                cluster.Should().BeEquivalentTo(cluster2);
-                var emptyNode = cluster.Elements.First() as DotNode;
-                var emptyNode2 = cluster2.Elements.First() as DotNode;
-                emptyNode.Should().BeEquivalentTo(emptyNode2);
-            }
-
-            [Theory, AutoData]
-            public void Test(string id)
-            {
-                var node = TypeNode<Empty>();
-                var typeCluster = new DotSubGraph(id);
-                typeCluster.Elements.Add(new DotNode(node.Children.Single().Id));
-
-                var typeCluster2 = new DotSubGraph(id);
-
-                using var a = new AssertionScope();
-                typeCluster.Should().BeEquivalentTo(typeCluster2);
-                typeCluster2.Should().BeEquivalentTo(typeCluster);
+                graph.Should().BeEquivalentTo(graph2, options => options.RespectingRuntimeTypes());
             }
         }
 

--- a/src/Cshart/Cshart.Tests/Chart_Add.cs
+++ b/src/Cshart/Cshart.Tests/Chart_Add.cs
@@ -46,16 +46,23 @@ namespace Cshart.Tests
                 var node = TypeNode<Empty>();
 
                 var graph = chart.ConvertToDotGraph(node.Yield());
+                var graph2 = RootGraph(
+                    TypeCluster(
+                        node,
+                        new DotNode(node.Children.Single().Id)));
 
-                graph.Should().BeEquivalentTo(
-                    RootGraph(
-                        TypeCluster(
-                            node
-                            ,
-                            new DotNode(node.Children.Single().Id)
-                            )));
+                using var a = new AssertionScope();
+                graph.Should().BeEquivalentTo(graph2);
+                // https://github.com/fluentassertions/fluentassertions/issues/978#issuecomment-441060261
+                // var cluster = graph.Elements.First();
+                // var cluster2 = graph2.Elements.First();
+                var cluster = graph.Elements.First() as DotSubGraph;
+                var cluster2 = graph2.Elements.First() as DotSubGraph;
+                cluster.Should().BeEquivalentTo(cluster2);
+                var emptyNode = cluster.Elements.First() as DotNode;
+                var emptyNode2 = cluster2.Elements.First() as DotNode;
+                emptyNode.Should().BeEquivalentTo(emptyNode2);
             }
-
 
             [Theory, AutoData]
             public void Test(string id)
@@ -70,7 +77,6 @@ namespace Cshart.Tests
                 typeCluster.Should().BeEquivalentTo(typeCluster2);
                 typeCluster2.Should().BeEquivalentTo(typeCluster);
             }
-
         }
 
         // TODO write first e2e test

--- a/src/Cshart/Cshart.Tests/ExploratoryTests_FluentAssertions.cs
+++ b/src/Cshart/Cshart.Tests/ExploratoryTests_FluentAssertions.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using AutoFixture.Xunit2;
+using DotNetGraph.Node;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Cshart.Tests
+{
+    public static class ExploratoryTests_
+    {
+        public class FluentAssertions
+        {
+            // FluentAssertion will never compare the actual types
+            // see https://github.com/fluentassertions/fluentassertions/issues/978#issuecomment-441060261
+            [Theory, AutoData]
+            public void Considers_Subgraph_equivalent_even_when_elements_are_different(
+                string graphId,
+                DotNode dotNode1,
+                DotNode dotNode2)
+            {
+                var graph1 = new SubGraph(graphId);
+                graph1.Elements.Add(dotNode1);
+
+                var graph2 = new SubGraph(graphId);
+                graph2.Elements.Add(dotNode2);
+
+                using var a = new AssertionScope();
+                graph1.Should().BeEquivalentTo(graph2);
+                var cluster = graph1.Elements.First() as DotNode;
+                var cluster2 = graph2.Elements.First() as DotNode;
+                cluster.Should().NotBeEquivalentTo(cluster2);
+            }
+
+            [Theory, AutoData]
+            public void Considers_Subgraph_unequal_when_runtime_types_should_be_checked(
+                string graphId,
+                DotNode dotNode1,
+                DotNode dotNode2)
+            {
+                var graph1 = new SubGraph(graphId);
+                graph1.Elements.Add(dotNode1);
+
+                var graph2 = new SubGraph(graphId);
+                graph2.Elements.Add(dotNode2);
+
+                graph1.Should().NotBeEquivalentTo(graph2, options => options.RespectingRuntimeTypes());
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've investigated the false positive test and found the issue.
Since `IDotElement` is an empty interface any two object will be considered equal unless you tell AF to respect runtime types. 
Exploratory tests added.